### PR TITLE
Fix debug property check -> should be debugState

### DIFF
--- a/src/API/ApiCommunication.php
+++ b/src/API/ApiCommunication.php
@@ -147,7 +147,7 @@ class ApiCommunication
 
     function debug($str)
     {
-        if ($this->debug) {
+        if ($this->debugState) {
             error_log('SendSMS: ' . $str);
         }
     }


### PR DESCRIPTION
debug method generates an error an interrupts code execution: shouldn't the prop checked in debug be debugState?